### PR TITLE
[docs] Update translation schedule for "Get Started" related translation status (zh-TW)

### DIFF
--- a/schedule_zh-TW.md
+++ b/schedule_zh-TW.md
@@ -41,9 +41,10 @@ io-redis |  | |
 io-solr |  | | 
 io-tcp |  | | 
 security-extending |  | | 
-getting-started-standalone (Correspond 'Run Pulsar locally') | | | 
-getting-started-docker |  | | 
-getting-started-clients |  | | 
+getting-started-pulsar | erhwenkuo | | Translated
+getting-started-standalone (Correspond 'Run Pulsar locally') | erhwenkuo | | Translated
+getting-started-docker | erhwenkuo  | | Translated
+getting-started-clients | erhwenkuo  | | Translated
 schema-get-started |  | | 
 schema-understand |  | | 
 schema-evolution-compatibility |  | | 


### PR DESCRIPTION
I've finished below translation, could you please help review?

## Modfied@crowdin (zh-TW)

* getting-started-pulsar.md
* getting-started-standalone.md
* getting-started-docker.md
* getting-started-clients.md



